### PR TITLE
Add travis-ci builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+---
+dist: trusty
+addons:
+  apt:
+    packages:
+    - libjansson-dev
+    - libjansson4
+language: cpp
+script: scons && scons test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# libxjwt: minimal library for validation of real-world JWTs
+# libxjwt: minimal C library for validation of real-world JWTs
+
+[![Build Status](https://travis-ci.org/ScaleFT/libxjwt.svg?branch=master)](https://travis-ci.org/ScaleFT/libxjwt)
 
 `libxjwt` seeks to provide a minimal c89-style library and API surface for validating a compact-form JWT against a set of JWKs. This is not meant to be a general purpose JOSE library.  If you are looking for a more general purpose C library, consider [cjose](https://github.com/cisco/cjose).
 

--- a/SConstruct
+++ b/SConstruct
@@ -26,7 +26,8 @@ from SCons.Script.SConscript import SConsEnvironment
 SConsEnvironment.Chmod = SCons.Action.ActionFactory(os.chmod,
         lambda dest, mode: 'Chmod("%s", 0%o)' % (dest, mode))
 
-EnsureSConsVersion(2, 4, 0)
+# Ubuntu LTS 14.04 Trusty includes SCons 2.3.0, so thats our minimum bar for now.
+EnsureSConsVersion(2, 3, 0)
 
 opts = Variables('build.py')
 


### PR DESCRIPTION
Now that libxjwt is open source, we can use travis-ci.org for basic builds and test runs on PRs.