### PR TITLE
Use _DEFAULT_SOURCE, as _BSD_SOURCE and _SVID_SOURCE are deprecated

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -111,7 +111,7 @@ options = {
       'CPPDEFINES': ['DARWIN'],
     },
     'LINUX': {
-      'CPPDEFINES': ['LINUX', '_XOPEN_SOURCE', '_BSD_SOURCE'],
+      'CPPDEFINES': ['LINUX', '_DEFAULT_SOURCE'],
     },
     'FREEBSD': {
       'CPPDEFINES': ['FREEBSD'],


### PR DESCRIPTION
On Debian-9:

```
/usr/include/features.h:148:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
   ^~~~~~~
```
