### PR TITLE
Typofix: Add apostrophe to What's New header

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 `libxjwt` seeks to provide a minimal c89-style library and API surface for validating a compact-form JWT against a set of JWKs. This is not meant to be a general purpose JOSE library.  If you are looking for a more general purpose C library, consider [cjose](https://github.com/cisco/cjose).
 
-# Whats New
+# What's New
 
 ## 1.0.1
 


### PR DESCRIPTION
Just a quick fix.