### PR TITLE
Automake build tweaks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,13 +1,10 @@
 ACLOCAL_AMFLAGS = -I m4
 
+dist_doc_DATA = README.md NOTICE LICENSE CONTRIBUTING.md CODE_OF_CONDUCT.md
+
 EXTRA_DIST = .clang-format \
     buildconf.sh \
-    CODE_OF_CONDUCT.md \
-    CONTRIBUTING.md \
-    NOTICE \
-    LICENSE \
-    ./dist/rpm/libxjwt.spec \
-    README.md
+    ./dist/rpm/libxjwt.spec
 
 lib_LTLIBRARIES = libxjwt.la
 check_LIBRARIES = libcmockery.a

--- a/Makefile.in
+++ b/Makefile.in
@@ -15,6 +15,7 @@
 @SET_MAKE@
 
 
+
 VPATH = @srcdir@
 am__is_gnu_make = { \
   if test -z '$(MAKELEVEL)'; then \
@@ -99,7 +100,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
 DIST_COMMON = $(srcdir)/Makefile.am $(top_srcdir)/configure \
-	$(am__configure_deps) $(xjwtinclude_HEADERS) \
+	$(am__configure_deps) $(dist_doc_DATA) $(xjwtinclude_HEADERS) \
 	$(am__DIST_COMMON)
 am__CONFIG_DISTCLEAN_FILES = config.status config.cache config.log \
  configure.lineno config.status.lineno
@@ -145,7 +146,8 @@ am__uninstall_files_from_dir = { \
     || { echo " ( cd '$$dir' && rm -f" $$files ")"; \
          $(am__cd) "$$dir" && rm -f $$files; }; \
   }
-am__installdirs = "$(DESTDIR)$(libdir)" "$(DESTDIR)$(xjwtincludedir)"
+am__installdirs = "$(DESTDIR)$(libdir)" "$(DESTDIR)$(docdir)" \
+	"$(DESTDIR)$(xjwtincludedir)"
 LTLIBRARIES = $(lib_LTLIBRARIES)
 libxjwt_la_LIBADD =
 am_libxjwt_la_OBJECTS = src/libxjwt_la-b64.lo src/libxjwt_la-error.lo \
@@ -210,6 +212,7 @@ am__can_run_installinfo = \
     n|no|NO) false;; \
     *) (install-info --version) >/dev/null 2>&1;; \
   esac
+DATA = $(dist_doc_DATA)
 HEADERS = $(xjwtinclude_HEADERS)
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
 # Read a list of newline-separated strings from the standard input,
@@ -553,9 +556,9 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 ACLOCAL_AMFLAGS = -I m4
-EXTRA_DIST = .clang-format buildconf.sh CODE_OF_CONDUCT.md \
-	CONTRIBUTING.md NOTICE LICENSE ./dist/rpm/libxjwt.spec \
-	README.md vendor/cmockery/COPYING vendor/cmockery/README \
+dist_doc_DATA = README.md NOTICE LICENSE CONTRIBUTING.md CODE_OF_CONDUCT.md
+EXTRA_DIST = .clang-format buildconf.sh ./dist/rpm/libxjwt.spec \
+	vendor/cmockery/COPYING vendor/cmockery/README \
 	./tests/fixtures/e1_af.jwt ./tests/fixtures/e1_jwk.json \
 	./tests/fixtures/jwk_af.json
 lib_LTLIBRARIES = libxjwt.la
@@ -962,6 +965,27 @@ clean-libtool:
 
 distclean-libtool:
 	-rm -f libtool config.lt
+install-dist_docDATA: $(dist_doc_DATA)
+	@$(NORMAL_INSTALL)
+	@list='$(dist_doc_DATA)'; test -n "$(docdir)" || list=; \
+	if test -n "$$list"; then \
+	  echo " $(MKDIR_P) '$(DESTDIR)$(docdir)'"; \
+	  $(MKDIR_P) "$(DESTDIR)$(docdir)" || exit 1; \
+	fi; \
+	for p in $$list; do \
+	  if test -f "$$p"; then d=; else d="$(srcdir)/"; fi; \
+	  echo "$$d$$p"; \
+	done | $(am__base_list) | \
+	while read files; do \
+	  echo " $(INSTALL_DATA) $$files '$(DESTDIR)$(docdir)'"; \
+	  $(INSTALL_DATA) $$files "$(DESTDIR)$(docdir)" || exit $$?; \
+	done
+
+uninstall-dist_docDATA:
+	@$(NORMAL_UNINSTALL)
+	@list='$(dist_doc_DATA)'; test -n "$(docdir)" || list=; \
+	files=`for p in $$list; do echo $$p; done | sed -e 's|^.*/||'`; \
+	dir='$(DESTDIR)$(docdir)'; $(am__uninstall_files_from_dir)
 install-xjwtincludeHEADERS: $(xjwtinclude_HEADERS)
 	@$(NORMAL_INSTALL)
 	@list='$(xjwtinclude_HEADERS)'; test -n "$(xjwtincludedir)" || list=; \
@@ -1373,9 +1397,9 @@ check-am: all-am
 	$(MAKE) $(AM_MAKEFLAGS) $(check_LIBRARIES) $(check_PROGRAMS)
 	$(MAKE) $(AM_MAKEFLAGS) check-TESTS
 check: check-am
-all-am: Makefile $(LTLIBRARIES) $(HEADERS)
+all-am: Makefile $(LTLIBRARIES) $(DATA) $(HEADERS)
 installdirs:
-	for dir in "$(DESTDIR)$(libdir)" "$(DESTDIR)$(xjwtincludedir)"; do \
+	for dir in "$(DESTDIR)$(libdir)" "$(DESTDIR)$(docdir)" "$(DESTDIR)$(xjwtincludedir)"; do \
 	  test -z "$$dir" || $(MKDIR_P) "$$dir"; \
 	done
 install: install-am
@@ -1441,7 +1465,7 @@ info: info-am
 
 info-am:
 
-install-data-am: install-xjwtincludeHEADERS
+install-data-am: install-dist_docDATA install-xjwtincludeHEADERS
 
 install-dvi: install-dvi-am
 
@@ -1489,7 +1513,8 @@ ps: ps-am
 
 ps-am:
 
-uninstall-am: uninstall-libLTLIBRARIES uninstall-xjwtincludeHEADERS
+uninstall-am: uninstall-dist_docDATA uninstall-libLTLIBRARIES \
+	uninstall-xjwtincludeHEADERS
 
 .MAKE: check-am install-am install-strip
 
@@ -1502,16 +1527,16 @@ uninstall-am: uninstall-libLTLIBRARIES uninstall-xjwtincludeHEADERS
 	distclean-hdr distclean-libtool distclean-tags distcleancheck \
 	distdir distuninstallcheck dvi dvi-am html html-am info \
 	info-am install install-am install-data install-data-am \
-	install-dvi install-dvi-am install-exec install-exec-am \
-	install-html install-html-am install-info install-info-am \
-	install-libLTLIBRARIES install-man install-pdf install-pdf-am \
-	install-ps install-ps-am install-strip \
+	install-dist_docDATA install-dvi install-dvi-am install-exec \
+	install-exec-am install-html install-html-am install-info \
+	install-info-am install-libLTLIBRARIES install-man install-pdf \
+	install-pdf-am install-ps install-ps-am install-strip \
 	install-xjwtincludeHEADERS installcheck installcheck-am \
 	installdirs maintainer-clean maintainer-clean-generic \
 	mostlyclean mostlyclean-compile mostlyclean-generic \
 	mostlyclean-libtool pdf pdf-am ps ps-am recheck tags tags-am \
-	uninstall uninstall-am uninstall-libLTLIBRARIES \
-	uninstall-xjwtincludeHEADERS
+	uninstall uninstall-am uninstall-dist_docDATA \
+	uninstall-libLTLIBRARIES uninstall-xjwtincludeHEADERS
 
 .PRECIOUS: Makefile
 

--- a/configure
+++ b/configure
@@ -1435,7 +1435,7 @@ Optional Packages:
   --with-sysroot[=DIR]    Search for dependent libraries within DIR (or the
                           compiler's sysroot if not specified).
   --with-openssl=DIR      root of the OpenSSL directory
-  --with-jansson          Path to Jansson
+  --with-jansson=DIR      Path to Jansson
 
 Some influential environment variables:
   CC          C compiler command
@@ -12473,10 +12473,15 @@ fi
 
 
 if test "x$with_jansson" != "x"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: Found --with-jansson=${with_jansson}" >&5
+$as_echo "$as_me: Found --with-jansson=${with_jansson}" >&6;}
+fi
+
+if test "x$with_jansson" != "x"; then :
   CPPFLAGS="$CPPFLAGS -I${with_jansson}/include"
 fi
 if test "x$with_jansson" != "x"; then :
-  LDFLAGS="$LDFLAGS -I${with_jansson}/lib"
+  LDFLAGS="$LDFLAGS -L${with_jansson}/lib -Wl,-rpath,${with_jansson}/lib"
 fi
 
 
@@ -12609,7 +12614,7 @@ _ACEOF
   LIBS="-ljansson $LIBS"
 
 else
-  as_fn_error $? "Jansson libraries required" "$LINENO" 5
+  as_fn_error $? "Jansson libraries required. Try adding --with-jansson=DIR" "$LINENO" 5
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -36,15 +36,18 @@ AC_CHECK_LIB([crypto],[EVP_PKEY_free], [], [AC_MSG_ERROR([OpenSSL libraries requ
 AC_CHECK_HEADERS([openssl/evp.h],[],[AC_MSG_ERROR([OpenSSL headers required])])
 
 AC_ARG_WITH([jansson],
-    [AS_HELP_STRING([--with-jansson],
+    [AS_HELP_STRING([--with-jansson=DIR],
     [Path to Jansson])],
     [with_jansson=$withval],
     [])
 
 AS_IF([test "x$with_jansson" != "x"],
+    [AC_MSG_NOTICE([Found --with-jansson=${with_jansson}])])
+
+AS_IF([test "x$with_jansson" != "x"],
     [CPPFLAGS="$CPPFLAGS -I${with_jansson}/include"])
 AS_IF([test "x$with_jansson" != "x"],
-    [LDFLAGS="$LDFLAGS -I${with_jansson}/lib"])
+    [LDFLAGS="$LDFLAGS -L${with_jansson}/lib -Wl,-rpath,${with_jansson}/lib"])
 
 AX_CHECK_LIBRARY([JANSSON],[jansson.h],[jansson], [],
     [AC_MSG_ERROR([Unable to find libjansson])])
@@ -53,7 +56,7 @@ if test "x$ax_cv_have_JANSSON" = "xyes"; then
   CFLAGS="$CFLAGS $JANSSON_CPPFLAGS"
   LDFLAGS="$LDFLAGS $JANSSON_LDFLAGS"
 fi
-AC_CHECK_LIB([jansson],[json_true], [], [AC_MSG_ERROR([Jansson libraries required])])
+AC_CHECK_LIB([jansson],[json_true], [], [AC_MSG_ERROR([Jansson libraries required. Try adding --with-jansson=DIR])])
 
 AC_CONFIG_HEADERS([src/internal/xjwt_config.h])
 AC_CONFIG_FILES([Makefile])


### PR DESCRIPTION
- Install README, LICENSE, etc as part of the docs target
- Use updated `--with-jansson` parsing in `configure.ac`, based on edge cases  and user experiences from how mod_auth_accessfabric is doing it.