### PR TITLE
makes the spec more portable and fixes release path

### DIFF
--- a/dist/rpm/libxjwt.spec
+++ b/dist/rpm/libxjwt.spec
@@ -51,3 +51,4 @@ cd %{name}-%{version}
 make DESTDIR=$RPM_BUILD_ROOT install
 
 %post -p /sbin/ldconfig
+%postun -p /sbin/ldconfig

--- a/dist/rpm/libxjwt.spec
+++ b/dist/rpm/libxjwt.spec
@@ -1,5 +1,5 @@
 Name:           libxjwt
-Version:        1.0.2
+Version:        1.0.3
 Release:        1%{?dist}
 
 Summary:        Minimal C library for validation of real-world JWTs

--- a/dist/rpm/libxjwt.spec
+++ b/dist/rpm/libxjwt.spec
@@ -1,5 +1,5 @@
 Name:           libxjwt
-Version:        1.0.3
+Version:        1.0.2
 Release:        1%{?dist}
 
 Summary:        Minimal C library for validation of real-world JWTs
@@ -21,7 +21,7 @@ libxjwt seeks to provide a minimal c89-style library and API surface for validat
 
 %files
 %{_prefix}/lib/%{name}.*
-%license $RPM_BUILD_DIR/%{name}-%{version}/LICENSE
+%{_prefix}/share/doc/%{name}
 %doc $RPM_BUILD_DIR/%{name}-%{version}/README.md
 
 %package -n %{name}-devel
@@ -38,7 +38,7 @@ Provides:       %{name}-devel = %{version}-%{release}
 
 %prep
 rm -Rf $RPM_BUILD_DIR/%{name}-%{version}
-tar xvfz $RPM_SOURCE_DIR/v%{version}.tar.gz -C $RPM_BUILD_DIR/
+tar xvfz $RPM_SOURCE_DIR/%{name}-%{version}.tar.gz -C $RPM_BUILD_DIR/
 
 %build
 cd %{name}-%{version}
@@ -49,3 +49,5 @@ make
 [ "$RPM_BUILD_ROOT" != "/" ] && rm -rf $RPM_BUILD_ROOT
 cd %{name}-%{version}
 make DESTDIR=$RPM_BUILD_ROOT install
+
+%post -p /sbin/ldconfig


### PR DESCRIPTION
This fixes that path to the release file so rpmbuild cat fetch the source and does an ldconfig which is necessary on CentOS6/AWS linux(1)

It also fixes some issues with the license file reference that worked on CentOS7 but was failing with the older version of rpmbuild on 6/AWS Linux.

Still works on CentOS7.